### PR TITLE
ustcmirror (yuki with mirrorindex) support

### DIFF
--- a/static/json/cname.json
+++ b/static/json/cname.json
@@ -1,4 +1,18 @@
 {
   "PuTTY": "putty",
-  "putty": "putty"
+  "putty": "putty",
+  "aosp": "AOSP",
+  "armbian-dl": "armbian-releases",
+  "bioc": "bioconductor",
+  "crates.io-index": "crates.io-index.git",
+  "debian-multimedia": "deb-multimedia",
+  "lineageos": "lineageOS",
+  "mysql-repo": "mysql",
+  "postmarketos": "postmarketOS",
+  "postmarketos-images": "postmarketOS-images",
+  "qtproject": "qt",
+  "salt": "saltstack",
+  "tdf": "libreoffice",
+  "wine": "winehq",
+  "xbmc": "kodi"
 }

--- a/yuki-mirrorindex/mirrorz.py
+++ b/yuki-mirrorindex/mirrorz.py
@@ -1,0 +1,77 @@
+import json
+import sys
+# import requests
+# import subprocess
+import re
+import sys
+
+
+content_regex = re.compile(r"\('(.+)', '(.*)', '(.*)', '(.+)'\)")
+
+
+def iso(iso_orig: list) -> None:
+    # modify iso_orig inplace
+    for i in iso_orig:
+        if not i.get("category"):
+            i["category"] = "os"  # now ustcmirror has no category and all iso are OS.
+
+
+def parse_content_meta(content_txt: str, meta: dict) -> dict:
+    content_raw_list = content_txt.split("\n")
+    content_list = []
+    content_hash = {}
+    for i in content_raw_list:
+        item = content_regex.match(i)
+        if not item:
+            print(f"failed to parse content line {i}", file=sys.stderr)
+            continue
+        _, help_url, _, name = item.groups()
+        content_hash[name.lower()] = len(content_list)
+        content_list.append({
+            "cname": name,
+            "desc": "",  # now we don't have desc yet...
+            "url": f"https://mirrors.ustc.edu.cn/{name}",
+            "status": "U",
+            "help": help_url,
+            "upstream": None
+        })
+    # now we add data to content_list with meta!
+    for i in meta:
+        try:
+            ind = content_hash[i["name"]]
+            if i["syncing"]:
+                content_list[ind]["status"] = "Y"
+            elif i["exitCode"] == 0:
+                content_list[ind]["status"] = "S"
+            else:
+                content_list[ind]["status"] = "F"
+            content_list[ind]["upstream"] = i["upstream"]
+        except KeyError:
+            print(f"failed to parse {i['name']}", file=sys.stderr)
+    return content_list
+
+
+def main():
+    if len(sys.argv) < 5:
+        print("help: mirrorz.py site.json meta_url genisolist_prog gencontent_prog")
+        sys.exit(0)
+    # site = json.loads(open(sys.argv[1]).read())
+    # meta = requests.get(sys.argv[2]).json()
+    # isolist = subprocess.check_output(sys.argv[3])
+    # content = subprocess.check_output(sys.argv[4])
+    site = json.loads(open(sys.argv[1]).read())
+    meta = json.loads(open(sys.argv[2]).read())
+    isolist = json.loads(open(sys.argv[3]).read())
+    content_txt = open(sys.argv[4]).read()
+
+    iso(isolist)
+    mirrors = parse_content_meta(content_txt, meta)
+
+    mirrorz = {}
+    mirrorz["site"] = site
+    mirrorz["info"] = iso(isolist)
+    mirrorz["mirrors"] = mirrors
+    print(json.dumps(mirrorz))
+
+if __name__ == '__main__':
+    main()

--- a/yuki-mirrorindex/mirrorz.py
+++ b/yuki-mirrorindex/mirrorz.py
@@ -31,10 +31,10 @@ def parse_content_meta(content_txt: str, meta: dict) -> dict:
         content_list.append({
             "cname": name,
             "desc": "",  # now we don't have desc yet...
-            "url": f"https://mirrors.ustc.edu.cn/{name}",
+            "url": f"/{name}",
             "status": "U",
             "help": help_url,
-            "upstream": None
+            "upstream": ""
         })
     # now we add data to content_list with meta!
     for i in meta:

--- a/yuki-mirrorindex/mirrorz.py
+++ b/yuki-mirrorindex/mirrorz.py
@@ -1,7 +1,7 @@
 import json
 import sys
-# import requests
-# import subprocess
+import requests
+import subprocess
 import re
 import sys
 
@@ -13,7 +13,8 @@ def iso(iso_orig: list) -> None:
     # modify iso_orig inplace
     for i in iso_orig:
         if not i.get("category"):
-            i["category"] = "os"  # now ustcmirror has no category and all iso are OS.
+            # now ustcmirror has no category and all iso are OS.
+            i["category"] = "os"
 
 
 def parse_content_meta(content_txt: str, meta: dict) -> dict:
@@ -55,14 +56,15 @@ def main():
     if len(sys.argv) < 5:
         print("help: mirrorz.py site.json meta_url genisolist_prog gencontent_prog")
         sys.exit(0)
-    # site = json.loads(open(sys.argv[1]).read())
-    # meta = requests.get(sys.argv[2]).json()
-    # isolist = subprocess.check_output(sys.argv[3])
-    # content = subprocess.check_output(sys.argv[4])
     site = json.loads(open(sys.argv[1]).read())
-    meta = json.loads(open(sys.argv[2]).read())
-    isolist = json.loads(open(sys.argv[3]).read())
-    content_txt = open(sys.argv[4]).read()
+    meta = requests.get(sys.argv[2]).json()
+    isolist = json.loads(subprocess.check_output(
+        sys.argv[3], stderr=subprocess.DEVNULL).decode('utf-8'))
+    content_txt = subprocess.check_output(
+        sys.argv[4], stderr=subprocess.DEVNULL).decode('utf-8')
+    # meta = json.loads(open(sys.argv[2]).read())
+    # isolist = json.loads(open(sys.argv[3]).read())
+    # content_txt = open(sys.argv[4]).read()
 
     iso(isolist)
     mirrors = parse_content_meta(content_txt, meta)
@@ -72,6 +74,7 @@ def main():
     mirrorz["info"] = iso(isolist)
     mirrorz["mirrors"] = mirrors
     print(json.dumps(mirrorz))
+
 
 if __name__ == '__main__':
     main()

--- a/yuki-mirrorindex/mirrorz.py
+++ b/yuki-mirrorindex/mirrorz.py
@@ -39,7 +39,10 @@ def parse_content_meta(content_txt: str, meta: dict) -> dict:
     # now we add data to content_list with meta!
     for i in meta:
         try:
-            ind = content_hash[i["name"]]
+            try:
+                ind = content_hash[i["name"]]
+            except KeyError:
+                ind = content_hash[i["name"].split(".")[0]]  # fix repo name like "kubernetes.apt"
             if i["syncing"]:
                 content_list[ind]["status"] = "Y"
             elif i["exitCode"] == 0:
@@ -71,7 +74,7 @@ def main():
 
     mirrorz = {}
     mirrorz["site"] = site
-    mirrorz["info"] = iso(isolist)
+    mirrorz["info"] = isolist
     mirrorz["mirrors"] = mirrors
     print(json.dumps(mirrorz))
 


### PR DESCRIPTION
用一个小时左右糊了一个实现。实现比较丑，并且可能还有一些 bug。

各个文件的内容参考 <https://gist.github.com/taoky/3c4436c8cb7ffd4ca94d9b033de4d512>。

另外多了一个 `requests` 的 Python 依赖，用来从 Yuki 的 HTTP API 请求其管理的镜像列表。（没有加 requirements.txt）